### PR TITLE
Various fixes and cleanup

### DIFF
--- a/cmd/pnp.go
+++ b/cmd/pnp.go
@@ -181,17 +181,19 @@ func generatePnPFile(csvPath string, prefix string) error {
 		pdfCanvas_one, pdfContext_one = addCardToPage(&imageCount_one, cardImg, pdfCanvas_one, pdfContext_one, p_one)
 
 		// Create individual card file
-		cardName := card.Attributes.Title
-		cardImgFilePath := fmt.Sprintf("%s/%d_%s.png", outputDir, cardID, cardName)
-		imgFile, err := os.Create(cardImgFilePath)
-		if err != nil {
-			return err
+		if genIndividualImages {
+			cardName := card.Attributes.Title
+			cardImgFilePath := fmt.Sprintf("%s/%d_%s.png", outputDir, cardID, cardName)
+			imgFile, err := os.Create(cardImgFilePath)
+			if err != nil {
+				return err
+			}
+			cardCanvas := canvas.New(60, 88)
+			cardContext := canvas.NewContext(cardCanvas)
+			cardContext.DrawImage(0, 0, cardImg.Data, canvas.DPMM(cardImg.DPMM))
+			renderers.PNG(canvas.DPMM(cardImg.DPMM))(imgFile, cardCanvas)
+			imgFile.Close()
 		}
-		cardCanvas := canvas.New(60, 88)
-		cardContext := canvas.NewContext(cardCanvas)
-		cardContext.DrawImage(0, 0, cardImg.Data, canvas.DPMM(cardImg.DPMM))
-		renderers.PNG(canvas.DPMM(cardImg.DPMM))(imgFile, cardCanvas)
-		imgFile.Close()
 
 		cardID += 1
 	}

--- a/cmd/pnp.go
+++ b/cmd/pnp.go
@@ -148,8 +148,8 @@ func generatePnPFile(csvPath string) error {
 			card.Attributes.Title = fmt.Sprintf("%s %s", cardNamePrefix, card.Attributes.Title)
 		}
 
-		// Generate card image
-		imgPath := fmt.Sprintf("piggybank_images/%d.png", cardID)
+		// Create image drawer
+		imgPath := fmt.Sprintf("%s/%d.png", imageDir, cardID)
 		_, imgFileErr := os.Stat(imgPath)
 		var drawer art.Drawer
 		drawer = emptyDrawer{}
@@ -158,6 +158,8 @@ func generatePnPFile(csvPath string) error {
 				filename: imgPath,
 			}
 		}
+
+		// Create canvas
 		cnv, err := generateCardCanvas(drawer, card, "", "")
 		if err != nil {
 			return err

--- a/cmd/pnp.go
+++ b/cmd/pnp.go
@@ -43,18 +43,18 @@ func newCardImage(data *image.RGBA) cardImage {
 }
 
 var pnpCmd = &cobra.Command{
-	Use:   "pnp [CSV file] [Prefix]",
-	Args:  cobra.MinimumNArgs(2),
-	Short: "Generate a print & play file containing cards from a CSV. Card Titles can be prepended with a prefix for version tracking",
+	Use:   "pnp [CSV file]",
+	Args:  cobra.MinimumNArgs(1),
+	Short: "Generate a print & play file containing cards from a CSV.",
 	Run: func(cmd *cobra.Command, args []string) {
-		if err := generatePnPFile(args[0], args[1]); err != nil {
+		if err := generatePnPFile(args[0]); err != nil {
 			log.Println("error:", err)
 			os.Exit(1)
 		}
 	},
 }
 
-func generatePnPFile(csvPath string, prefix string) error {
+func generatePnPFile(csvPath string) error {
 	// Load CSV file
 	csvFile, err := os.Open(csvPath)
 	if err != nil {
@@ -143,8 +143,10 @@ func generatePnPFile(csvPath string, prefix string) error {
 		}
 		card := buildCard(record, cardID)
 
-		// prepend 'Dev 8.2' etc
-		card.Attributes.Title = fmt.Sprintf("%s %s", prefix, card.Attributes.Title)
+		// Prepend card name prefix
+		if cardNamePrefix != "" {
+			card.Attributes.Title = fmt.Sprintf("%s %s", cardNamePrefix, card.Attributes.Title)
+		}
 
 		// Generate card image
 		imgPath := fmt.Sprintf("piggybank_images/%d.png", cardID)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,8 @@ var (
 	designer string
 
 	// pnp
-	startRow int
+	startRow            int
+	genIndividualImages bool
 
 	// set by ldflags
 	version string = "local"
@@ -131,6 +132,7 @@ If set to "faction", it will use the faction color regardless of the base color`
 	reflectionCmd.Flags().StringVarP(&colorBG, "color-bg", "", "", `Background color for the generated art, defaults to a darkened --base-color value`)
 
 	pnpCmd.Flags().IntVarP(&startRow, "start-row", "m", 2, `Row to start generating from, defaults to 1 (this assumes the CSV contains a header row)`)
+	pnpCmd.Flags().BoolVarP(&genIndividualImages, "gen-individual-images", "", false, `Generate a separate image file for each card in addition to the PnP sheets`)
 
 	rootCmd.AddCommand(netwalkerCmd)
 	rootCmd.AddCommand(emptyCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,9 +66,9 @@ var (
 	designer string
 
 	// pnp
-	startRow            int
-	genIndividualImages bool
-	cardNamePrefix      string
+	startRow                 int
+	genIndividualImages      bool
+	cardNamePrefix, imageDir string
 
 	// set by ldflags
 	version string = "local"
@@ -135,6 +135,7 @@ If set to "faction", it will use the faction color regardless of the base color`
 	pnpCmd.Flags().IntVarP(&startRow, "start-row", "m", 2, `Row to start generating from, defaults to 1 (this assumes the CSV contains a header row)`)
 	pnpCmd.Flags().BoolVar(&genIndividualImages, "gen-individual-images", false, `Generate a separate image file for each card in addition to the PnP sheets`)
 	pnpCmd.Flags().StringVar(&cardNamePrefix, "card-name-prefix", "", `Text to prepend to card titles (e.g. version tracking)`)
+	pnpCmd.Flags().StringVar(&imageDir, "image-dir", "", `Path to directory containing card images (named [cardID].png)`)
 
 	rootCmd.AddCommand(netwalkerCmd)
 	rootCmd.AddCommand(emptyCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,6 +68,7 @@ var (
 	// pnp
 	startRow            int
 	genIndividualImages bool
+	cardNamePrefix      string
 
 	// set by ldflags
 	version string = "local"
@@ -132,7 +133,8 @@ If set to "faction", it will use the faction color regardless of the base color`
 	reflectionCmd.Flags().StringVarP(&colorBG, "color-bg", "", "", `Background color for the generated art, defaults to a darkened --base-color value`)
 
 	pnpCmd.Flags().IntVarP(&startRow, "start-row", "m", 2, `Row to start generating from, defaults to 1 (this assumes the CSV contains a header row)`)
-	pnpCmd.Flags().BoolVarP(&genIndividualImages, "gen-individual-images", "", false, `Generate a separate image file for each card in addition to the PnP sheets`)
+	pnpCmd.Flags().BoolVar(&genIndividualImages, "gen-individual-images", false, `Generate a separate image file for each card in addition to the PnP sheets`)
+	pnpCmd.Flags().StringVar(&cardNamePrefix, "card-name-prefix", "", `Text to prepend to card titles (e.g. version tracking)`)
 
 	rootCmd.AddCommand(netwalkerCmd)
 	rootCmd.AddCommand(emptyCmd)

--- a/frame/basic/shapes.go
+++ b/frame/basic/shapes.go
@@ -82,8 +82,9 @@ func (fb FrameBasic) drawCostCircle(ctx *canvas.Context, bgColor color.Color) {
 }
 
 func (fb FrameBasic) drawRezCost(ctx *canvas.Context, card *nrdb.Printing, fontSize float64) (*textBoxDimensions, error) {
-	canvasWidth, canvasHeight := ctx.Size()
+	rezScale := 0.1 * ScaleFactor
 
+	canvasWidth, canvasHeight := ctx.Size()
 	strokeWidth := getStrokeWidth(ctx)
 
 	// res cost icon
@@ -91,7 +92,7 @@ func (fb FrameBasic) drawRezCost(ctx *canvas.Context, card *nrdb.Printing, fontS
 	if err != nil {
 		return nil, err
 	}
-	rezCostImage = rezCostImage.Transform(canvas.Identity.ReflectY()).Scale(0.1, 0.1).Scale(ScaleFactor, ScaleFactor)
+	rezCostImage = rezCostImage.Transform(canvas.Identity.ReflectY()).Scale(rezScale, rezScale)
 
 	ctx.Push()
 	ctx.SetFillColor(fb.getColorBG())
@@ -123,8 +124,9 @@ func (fb FrameBasic) drawRezCost(ctx *canvas.Context, card *nrdb.Printing, fontS
 }
 
 func (fb FrameBasic) drawAgendaPoints(ctx *canvas.Context, card *nrdb.Printing, fontSize float64) (*textBoxDimensions, error) {
-	canvasWidth, _ := ctx.Size()
+	agendaScale := 0.07 * ScaleFactor
 
+	canvasWidth, _ := ctx.Size()
 	strokeWidth := getStrokeWidth(ctx)
 
 	// res cost icon
@@ -132,7 +134,7 @@ func (fb FrameBasic) drawAgendaPoints(ctx *canvas.Context, card *nrdb.Printing, 
 	if err != nil {
 		return nil, err
 	}
-	icon = icon.Transform(canvas.Identity.ReflectY()).Scale(0.07, 0.07).Scale(ScaleFactor, ScaleFactor)
+	icon = icon.Transform(canvas.Identity.ReflectY()).Scale(agendaScale, agendaScale)
 
 	iconX := canvasWidth * 0.085
 	iconY := fb.getTextBoxHeight(ctx) + icon.Bounds().H*1.8
@@ -176,8 +178,8 @@ func (fb FrameBasic) drawAgendaPoints(ctx *canvas.Context, card *nrdb.Printing, 
 }
 
 func loadTrashCostPath() *canvas.Path {
+	trashScale := 0.005 * ScaleFactor
 
-	trashScale := 0.005
 	paths := make([]*canvas.Path, 5)
 	for i := range 5 {
 		path := mustLoadGameAsset(fmt.Sprintf("TRASH_COST_%d", i))
@@ -186,7 +188,6 @@ func loadTrashCostPath() *canvas.Path {
 	}
 
 	return paths[0].Join(paths[1]).Join(paths[2]).Join(paths[3]).Join(paths[4])
-
 }
 
 func (fb FrameBasic) drawTrashCost(ctx *canvas.Context, card *nrdb.Printing) (*textBoxDimensions, error) {
@@ -231,8 +232,9 @@ func (fb FrameBasic) drawTrashCost(ctx *canvas.Context, card *nrdb.Printing) (*t
 }
 
 func (fb FrameBasic) drawMU(ctx *canvas.Context, card *nrdb.Printing, drawBox bool) {
-	canvasWidth, _ := ctx.Size()
+	muScale := 0.05 * ScaleFactor
 
+	canvasWidth, _ := ctx.Size()
 	strokeWidth := getStrokeWidth(ctx)
 
 	// mu icon
@@ -240,7 +242,7 @@ func (fb FrameBasic) drawMU(ctx *canvas.Context, card *nrdb.Printing, drawBox bo
 	if err != nil {
 		panic(err)
 	}
-	muImage = muImage.Transform(canvas.Identity.ReflectY()).Scale(0.05, 0.05).Scale(ScaleFactor, ScaleFactor)
+	muImage = muImage.Transform(canvas.Identity.ReflectY()).Scale(muScale, muScale)
 
 	muBoxX := canvasWidth * 0.0853
 	muBoxY := (getTitleBoxTop(ctx) - getTitleBoxHeight(ctx)) - (muImage.Bounds().H * 0.8)
@@ -300,6 +302,8 @@ func (fb FrameBasic) drawMU(ctx *canvas.Context, card *nrdb.Printing, drawBox bo
 }
 
 func (fb FrameBasic) drawLink(ctx *canvas.Context, card *nrdb.Printing) {
+	linkScale := 0.015 * ScaleFactor
+
 	canvasWidth, _ := ctx.Size()
 
 	// link icon
@@ -307,7 +311,7 @@ func (fb FrameBasic) drawLink(ctx *canvas.Context, card *nrdb.Printing) {
 	if err != nil {
 		panic(err)
 	}
-	icon = icon.Transform(canvas.Identity.ReflectY()).Scale(0.015, 0.015).Scale(ScaleFactor, ScaleFactor)
+	icon = icon.Transform(canvas.Identity.ReflectY()).Scale(linkScale, linkScale)
 
 	boxX := canvasWidth * 0.1
 	boxY := getTitleBoxTop(ctx) - getTitleBoxHeight(ctx)*0.6

--- a/frame/basic/text.go
+++ b/frame/basic/text.go
@@ -190,10 +190,12 @@ var replacementCheck = regexp.MustCompile(`\[[a-z-]+\]`)
 
 func (fb FrameBasic) replaceSymbol(rt *canvas.RichText, symbol, svgName, text string, face *canvas.FontFace, scaleFactor, translateFactor float64) string {
 	if strings.Contains(text, symbol) {
+		fontScale := face.Size * scaleFactor
+
 		subParts := strings.Split(text, symbol)
 		for _, chunk := range subParts[:len(subParts)-1] {
 			fb.writeChunk(rt, chunk, face)
-			path := mustLoadGameAsset(svgName).Scale(face.Size*scaleFactor, face.Size*scaleFactor).Transform(canvas.Identity.ReflectY().Translate(0, face.Size*-1*translateFactor))
+			path := mustLoadGameAsset(svgName).Scale(fontScale, fontScale).Transform(canvas.Identity.ReflectY().Translate(0, face.Size*-1*translateFactor))
 			rt.WritePath(path, fb.getColorText(), canvas.FontMiddle)
 		}
 		text = subParts[len(subParts)-1]
@@ -203,7 +205,6 @@ func (fb FrameBasic) replaceSymbol(rt *canvas.RichText, symbol, svgName, text st
 	}
 
 	return text
-
 }
 
 func (fb FrameBasic) writeChunk(rt *canvas.RichText, text string, face *canvas.FontFace) {
@@ -425,12 +426,8 @@ func (fb FrameBasic) getTypeText(ctx *canvas.Context, card *nrdb.Printing, fontS
 	var tText *canvas.Text
 	typeName := getTypeName(card.Attributes.CardTypeID)
 
-	if card.Attributes.DisplaySubtypes != nil && card.Attributes.TrashCost != nil {
-		tText = fb.getFittedText(ctx, fmt.Sprintf("<strong>%s</strong> - %s - Trash: %d", typeName, *card.Attributes.DisplaySubtypes, *card.Attributes.TrashCost), fontSize, w, h, align)
-	} else if card.Attributes.DisplaySubtypes != nil && card.Attributes.TrashCost == nil {
+	if card.Attributes.DisplaySubtypes != nil {
 		tText = fb.getFittedText(ctx, fmt.Sprintf("<strong>%s</strong> - %s", typeName, *card.Attributes.DisplaySubtypes), fontSize, w, h, align)
-	} else if card.Attributes.TrashCost != nil {
-		tText = fb.getFittedText(ctx, fmt.Sprintf("<strong>%s</strong> - Trash: %d", typeName, *card.Attributes.TrashCost), fontSize, w, h, align)
 	} else {
 		tText = fb.getFittedText(ctx, fmt.Sprintf("<strong>%s</strong>", typeName), fontSize, w, h, align)
 	}

--- a/frame/basic/text.go
+++ b/frame/basic/text.go
@@ -273,7 +273,6 @@ type additionalText struct {
 }
 
 func (fb FrameBasic) drawCardText(ctx *canvas.Context, card *nrdb.Printing, fontSize, indentCutoff, indent float64, box textBoxDimensions, extra ...additionalText) {
-
 	if box.align == 0 {
 		box.align = canvas.Left
 	}
@@ -315,7 +314,7 @@ func (fb FrameBasic) drawCardText(ctx *canvas.Context, card *nrdb.Printing, font
 		lastLineH += extraH
 	}
 
-	for y-lastLineH < textBottom {
+	for y-lastLineH-paddingTB < textBottom {
 		fontSize -= strokeWidth
 		extraFontSize = math.Min(maxExtraFontSize, fontSize)
 
@@ -334,14 +333,12 @@ func (fb FrameBasic) drawCardText(ctx *canvas.Context, card *nrdb.Printing, font
 			extraH := txt.Bounds().H
 			lastLineH += extraH
 		}
-
 	}
 
 	i := 0
 	lastLineH = cText.Bounds().H
 
 	for y-lastLineH < indentCutoff {
-
 		i++
 
 		lines := strings.Split(card.Attributes.Text, "\n")
@@ -352,7 +349,6 @@ func (fb FrameBasic) drawCardText(ctx *canvas.Context, card *nrdb.Printing, font
 		cText = fb.getCardText(newText, fontSize, w, h, box.align)
 
 		lastLineH = cText.Bounds().H
-
 	}
 
 	ctx.DrawText(x, y, cText)
@@ -371,7 +367,7 @@ func (fb FrameBasic) drawCardText(ctx *canvas.Context, card *nrdb.Printing, font
 	}
 
 	newCardTextX += w * 0.08
-	y = y - (lastLineH + fontSize*0.4)
+	y -= lastLineH + fontSize*0.4
 	widestLine := 0.0
 	extraFontSize = math.Min(maxExtraFontSize, fontSize)
 	for _, ln := range extra {
@@ -388,7 +384,6 @@ func (fb FrameBasic) drawCardText(ctx *canvas.Context, card *nrdb.Printing, font
 		lastLineH = txt.Bounds().H
 		y = y - (lastLineH)
 	}
-
 }
 
 func getCardTextPadding(ctx *canvas.Context) (lr, tb float64) {


### PR DESCRIPTION
This PR contains several changes, all related to the `pnp` command:
- Trash cost icons now have scaling applied to hopefully resolve an issue where they weren't being rendered at certain scales.
- Font size calculation for text boxes was adjusted slightly to fix an issue where the last line could be partially cut off in some cases.
- Trim marks are now drawn onto the output PDFs.
- New flags
  - `--gen-individual-images`: This flag causes individual image files to be generated for each card from the input CSV file (default is `false`).
  - `--card-name-prefix`: This flag replaces the `pnp` command's prefix parameter and is optional.
  - `--imageDir`: This flag allows the user to specify the PnP image directory instead of it being hardcoded.
- Code cleanup
  - Application of `scaleFactor` has been standardized.
  - The code to add card images to a PDF has been extracted to a lambda function to reduce repetition.